### PR TITLE
Add Rainbow to investments portfolio

### DIFF
--- a/src/index.twig
+++ b/src/index.twig
@@ -237,6 +237,10 @@
                             </li>
                             <li>
                                 Mudafy
+                                {% include "elements/svg/approach-title-shape.twig" %}
+                            </li>
+                            <li>
+                                Rainbow
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
## Summary
• Add Rainbow to the investments list in the "our experience" section
• Update portfolio showcase to reflect expanded investment portfolio

## Test plan
- [ ] Verify Rainbow appears in the investments list on the website
- [ ] Confirm formatting matches existing entries
- [ ] Check that page layout remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)