### PR TITLE
Add URL redirects for modernized blog URLs

### DIFF
--- a/src/blog/2023/06/30/introducing-buzhi-early-stage-tech-investments.twig
+++ b/src/blog/2023/06/30/introducing-buzhi-early-stage-tech-investments.twig
@@ -6,6 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecting...</title>
     <link rel="canonical" href="/blog/introducing-buzhi-early-stage-tech-investments">
+    <style>
+        body {
+            background-color: #000;
+            color: #fff;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        a {
+            color: #fff;
+        }
+    </style>
 </head>
 <body>
     <p>This page has moved to <a href="/blog/introducing-buzhi-early-stage-tech-investments">/blog/introducing-buzhi-early-stage-tech-investments</a>.</p>

--- a/src/blog/2023/06/30/introducing-buzhi-early-stage-tech-investments.twig
+++ b/src/blog/2023/06/30/introducing-buzhi-early-stage-tech-investments.twig
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/blog/introducing-buzhi-early-stage-tech-investments">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    <link rel="canonical" href="/blog/introducing-buzhi-early-stage-tech-investments">
+</head>
+<body>
+    <p>This page has moved to <a href="/blog/introducing-buzhi-early-stage-tech-investments">/blog/introducing-buzhi-early-stage-tech-investments</a>.</p>
+    <script>
+        window.location.replace('/blog/introducing-buzhi-early-stage-tech-investments');
+    </script>
+</body>
+</html>

--- a/src/blog/2025/05/22/how-we-like-to-invest.twig
+++ b/src/blog/2025/05/22/how-we-like-to-invest.twig
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=/blog/how-we-like-to-invest">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redirecting...</title>
+    <link rel="canonical" href="/blog/how-we-like-to-invest">
+</head>
+<body>
+    <p>This page has moved to <a href="/blog/how-we-like-to-invest">/blog/how-we-like-to-invest</a>.</p>
+    <script>
+        window.location.replace('/blog/how-we-like-to-invest');
+    </script>
+</body>
+</html>

--- a/src/blog/2025/05/22/how-we-like-to-invest.twig
+++ b/src/blog/2025/05/22/how-we-like-to-invest.twig
@@ -6,6 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecting...</title>
     <link rel="canonical" href="/blog/how-we-like-to-invest">
+    <style>
+        body {
+            background-color: #000;
+            color: #fff;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+        a {
+            color: #fff;
+        }
+    </style>
 </head>
 <body>
     <p>This page has moved to <a href="/blog/how-we-like-to-invest">/blog/how-we-like-to-invest</a>.</p>


### PR DESCRIPTION
Add redirects from old date-based blog URLs to prevent broken links after URL modernization.

- Added redirect page for /blog/2025/05/22/how-we-like-to-invest → /blog/how-we-like-to-invest
- Added redirect page for /blog/2023/06/30/introducing-buzhi-early-stage-tech-investments → /blog/introducing-buzhi-early-stage-tech-investments
- Used comprehensive redirect approach with meta refresh, JavaScript, and canonical links

Fixes #12

Generated with [Claude Code](https://claude.ai/code)